### PR TITLE
"-lz" explicity needed in case libwebsockets/openssl libs does not specify it

### DIFF
--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -45,6 +45,9 @@ libmbus-server.so_ldflags-${WS_ENABLE} += \
 libmbus-server.so_cflags-${ZLIB_ENABLE} += \
 	-DZLIB_ENABLE=1
 
+libmbus-server.so_ldflags-${ZLIB_ENABLE} += \
+	-lz
+
 libmbus-server.a_files-y = \
 	${libmbus-server.so_files-y}
 


### PR DESCRIPTION
observed on macOS where pkg-config output is as follows
```
bash-3.2$ PKG_CONFIG_PATH=PATH_TO_BINARIES/rootfs/lib/pkgconfig pkg-config --libs openssl
-L/PATH_TO_BINARIES/rootfs/lib -lssl -lcrypto
bash-3.2$ 
bash-3.2$ PKG_CONFIG_PATH=PATH_TO_BINARIES/rootfs/lib/pkgconfig pkg-config --libs libwebsockets
-LPATH_TO_BINARIES/rootfs/lib -lwebsockets
```
with following error:
```
LINKSO     .libmbus-server.so/libmbus-server.so
Undefined symbols for architecture x86_64:
  "_deflate", referenced from:
      _lws_extension_callback_pm_deflate in libwebsockets.a(extension-permessage-deflate.c.o)
     (maybe you meant: _lws_extension_callback_pm_deflate, _lws_ext_pm_deflate_options )
  "_deflateEnd", referenced from:
      _lws_extension_callback_pm_deflate in libwebsockets.a(extension-permessage-deflate.c.o)
  "_deflateInit2_", referenced from:
      _lws_extension_callback_pm_deflate in libwebsockets.a(extension-permessage-deflate.c.o)
  "_inflate", referenced from:
      _lws_extension_callback_pm_deflate in libwebsockets.a(extension-permessage-deflate.c.o)
      _lws_fops_zip_read in libwebsockets.a(fops-zip.c.o)
  "_inflateEnd", referenced from:
      _lws_extension_callback_pm_deflate in libwebsockets.a(extension-permessage-deflate.c.o)
      _lws_fops_zip_open in libwebsockets.a(fops-zip.c.o)
      _lws_fops_zip_close in libwebsockets.a(fops-zip.c.o)
      _lws_fops_zip_read in libwebsockets.a(fops-zip.c.o)
  "_inflateInit2_", referenced from:
      _lws_extension_callback_pm_deflate in libwebsockets.a(extension-permessage-deflate.c.o)
      _lws_fops_zip_open in libwebsockets.a(fops-zip.c.o)
      _lws_fops_zip_read in libwebsockets.a(fops-zip.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[4]: *** [.libmbus-server.so/libmbus-server.so] Error 1
```