### PR TITLE
cross compilation failure fix for libwebsockets

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -5,11 +5,10 @@ ZLIB_ENABLE   ?= y
 SHARED_ENABLE ?= y
 
 ws_cflags-${WS_ENABLE} += \
-	-DWS_ENABLE=1 \
-	$(shell pkg-config --cflags libwebsockets)
+	-DWS_ENABLE=1
 
 ws_ldflags-${WS_ENABLE} += \
-	$(shell pkg-config --libs libwebsockets)
+	-lwebsockets
 
 ssl_cflags-${SSL_ENABLE} += \
 	-DSSL_ENABLE=1 \


### PR DESCRIPTION
Problem: if host system already has libwebsockets in
/usr/local/lib, cross compilation fails with the message:
WARNING: unsafe header/library path used in cross-compilation
/usr/local/lib/libwebsockets.so: file not recognized